### PR TITLE
Enhance: add testing and coverage reporting

### DIFF
--- a/.github/.testcoverage.yml
+++ b/.github/.testcoverage.yml
@@ -38,7 +38,7 @@ threshold:
 exclude:
   # Exclude files or packages matching their paths
   paths:
-    - \.mock\.    # excludes all generated mock files
+    - .*mock.*    # excludes all generated mock files
     - ^api/v1      # exclude api/v1 
     - ^test/       # exclude test files
     - ^cmd         # exclude cmd files

--- a/.github/.testcoverage.yml
+++ b/.github/.testcoverage.yml
@@ -1,0 +1,51 @@
+# (mandatory) 
+# Path to coverage profile file (output of `go test -coverprofile` command).
+#
+# For cases where there are many coverage profiles, such as when running 
+# unit tests and integration tests separately, you can combine all those
+# profiles into one. In this case, the profile should have a comma-separated list 
+# of profile files, e.g., 'cover_unit.out,cover_integration.out'.
+profile: cover.out
+
+# Holds coverage thresholds percentages, values should be in range [0-100].
+threshold:
+  # (optional; default 0) 
+  # Minimum coverage percentage required for individual files.
+  file: 0
+
+  # (optional; default 0) 
+  # Minimum coverage percentage required for each package.
+  package: 60
+
+  # (optional; default 0) 
+  # Minimum overall project coverage percentage required.
+  total: 60
+
+# Holds regexp rules which will override thresholds for matched files or packages 
+# using their paths.
+#
+# First rule from this list that matches file or package is going to apply 
+# new threshold to it. If project has multiple rules that match same path, 
+# override rules should be listed in order from specific to more general rules.
+# override:
+  # Increase coverage threshold to 100% for `foo` package 
+  # (default is 80, as configured above in this example).
+  # - path: ^pkg/lib/foo$
+  #   threshold: 100
+
+# Holds regexp rules which will exclude matched files or packages 
+# from coverage statistics.
+# exclude:
+  # Exclude files or packages matching their paths
+  # paths:
+  #   - \.pb\.go$    # excludes all protobuf generated files
+  #   - ^pkg/bar     # exclude package `pkg/bar`
+
+# File name of go-test-coverage breakdown file, which can be used to 
+# analyze coverage difference.
+# breakdown-file-name: ''
+
+# diff:
+  # # File name of go-test-coverage breakdown file which will be used to 
+  # # report coverage difference.
+  # base-breakdown-file-name: ''

--- a/.github/.testcoverage.yml
+++ b/.github/.testcoverage.yml
@@ -38,7 +38,7 @@ threshold:
 exclude:
   # Exclude files or packages matching their paths
   paths:
-    - \.mock\.$    # excludes all generated mock  files
+    - \.mock\.    # excludes all generated mock files
     - ^api/v1      # exclude api/v1 
     - ^test/       # exclude test files
     - ^cmd         # exclude cmd files

--- a/.github/.testcoverage.yml
+++ b/.github/.testcoverage.yml
@@ -35,11 +35,14 @@ threshold:
 
 # Holds regexp rules which will exclude matched files or packages 
 # from coverage statistics.
-# exclude:
-  # Exclude files or packages matching their paths
-  # paths:
-  #   - \.pb\.go$    # excludes all protobuf generated files
-  #   - ^pkg/bar     # exclude package `pkg/bar`
+exclude:
+  Exclude files or packages matching their paths
+  paths:
+    - \.mock\.$    # excludes all generated mock  files
+    - ^api/v1      # exclude api/v1 
+    - ^test/       # exclude test files
+    - ^cmd         # exclude cmd files
+
 
 # File name of go-test-coverage breakdown file, which can be used to 
 # analyze coverage difference.

--- a/.github/.testcoverage.yml
+++ b/.github/.testcoverage.yml
@@ -36,7 +36,7 @@ threshold:
 # Holds regexp rules which will exclude matched files or packages 
 # from coverage statistics.
 exclude:
-  Exclude files or packages matching their paths
+  # Exclude files or packages matching their paths
   paths:
     - \.mock\.$    # excludes all generated mock  files
     - ^api/v1      # exclude api/v1 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,21 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Running Tests
+      - name: Running Tests with Coverage
         run: |
           go mod tidy
           make test
+
+      - name: check test coverage
+        if: github.ref == 'refs/heads/main'
+        uses: vladopajic/go-test-coverage@v2
+        with:
+          config: ./.github/.testcoverage.yml
+          git-branch: badges
+          git-token: ${{ github.ref_name == 'main' && secrets.GITHUB_TOKEN || '' }}
+
+      - name: Check test coverage
+        if: github.ref != 'refs/heads/main'
+        uses: vladopajic/go-test-coverage@v2
+        with:
+          config: ./.github/.testcoverage.yml

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile ./cover.out -covermode=atomic -coverpkg=./...
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # operation-cache-controller
+[![Go Report Card](https://goreportcard.com/badge/github.com/Azure/operation-cache-controller)](https://goreportcard.com/report/github.com/Azure/operation-cache-controller)
+[![Go Test Status](https://github.com/Azure/operation-cache-controller/actions/workflows/go.yml/badge.svg)](https://github.com/Azure/operation-cache-controller/actions/workflows/test.yml)
+[![Go Test Coverage](https://raw.githubusercontent.com/Azure/operation-cache-controller/badges/.badges/main/coverage.svg)](/.github/.testcoverage.yml)
+
 A k8s controller used to manage operations and cache the outcome of that operation
+


### PR DESCRIPTION
- Updated the Makefile to include atomic coverage mode and package coverage in the test command.
- Added a new configuration file for test coverage thresholds and reporting.
- Modified the GitHub Actions workflow to include coverage checks and reporting based on the new configuration.